### PR TITLE
Re-wrap the websocket errors

### DIFF
--- a/dist/FxAccountsPairingChannel.babel.umd.js
+++ b/dist/FxAccountsPairingChannel.babel.umd.js
@@ -7,7 +7,7 @@
  * This uses the event-target-shim node library published under the MIT license:
  * https://github.com/mysticatea/event-target-shim/blob/master/LICENSE
  * 
- * Bundle generated from https://github.com/mozilla/fxa-pairing-channel.git. Hash:4a8833c9a323fd8a08d4, Chunkhash:eec061c954a47bcc2597.
+ * Bundle generated from https://github.com/mozilla/fxa-pairing-channel.git. Hash:04551ca6579dd3356b83, Chunkhash:f57f4414ce4a7d10f151.
  * 
  */
 (function webpackUniversalModuleDefinition(root, factory) {
@@ -2529,11 +2529,16 @@ function (_EventTarget) {
         return function (_x) {
           return _ref.apply(this, arguments);
         };
-      }()); // Relay the other events.
+      }()); // Relay the WebSocket events.
 
 
-      this._socket.addEventListener('error', function (e) {
-        return _this2.dispatchEvent(e);
+      this._socket.addEventListener('error', function () {
+        // The dispatched event that we receive has no useful information.
+        _this2.dispatchEvent(new CustomEvent('error', {
+          detail: {
+            error: new Error('WebSocket error.')
+          }
+        }));
       });
 
       this._socket.addEventListener('close', function (e) {

--- a/dist/FxAccountsPairingChannel.js
+++ b/dist/FxAccountsPairingChannel.js
@@ -7,7 +7,7 @@
  * This uses the event-target-shim node library published under the MIT license:
  * https://github.com/mysticatea/event-target-shim/blob/master/LICENSE
  * 
- * Bundle generated from https://github.com/mozilla/fxa-pairing-channel.git. Hash:aae6368ded0f29d51fdc, Chunkhash:ac5b7cfb50f4ad06e8d2.
+ * Bundle generated from https://github.com/mozilla/fxa-pairing-channel.git. Hash:dcdb14abba5a7db14360, Chunkhash:1ae02caf1a4926f6eb78.
  * 
  */
 
@@ -1285,8 +1285,15 @@ class src_InsecurePairingChannel extends EventTarget {
         }));
       }
     });
-    // Relay the other events.
-    this._socket.addEventListener('error', e => this.dispatchEvent(e));
+    // Relay the WebSocket events.
+    this._socket.addEventListener('error', () => {
+      // The dispatched event that we receive has no useful information.
+      this.dispatchEvent(new CustomEvent('error', {
+        detail: {
+          error: new Error('WebSocket error.'),
+        },
+      }));
+    });
     this._socket.addEventListener('close', e => this.dispatchEvent(e));
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -111,8 +111,15 @@ export class InsecurePairingChannel extends EventTarget {
         }));
       }
     });
-    // Relay the other events.
-    this._socket.addEventListener('error', e => this.dispatchEvent(e));
+    // Relay the WebSocket events.
+    this._socket.addEventListener('error', () => {
+      // The dispatched event that we receive has no useful information.
+      this.dispatchEvent(new CustomEvent('error', {
+        detail: {
+          error: new Error('WebSocket error.'),
+        },
+      }));
+    });
     this._socket.addEventListener('close', e => this.dispatchEvent(e));
   }
 


### PR DESCRIPTION
We do `e.detail.error` on desktop