### PR TITLE
Handle immediate `close` event on WebSocket like an `error` event.

### DIFF
--- a/dist/FxAccountsPairingChannel.babel.umd.js
+++ b/dist/FxAccountsPairingChannel.babel.umd.js
@@ -14,7 +14,7 @@
  * This uses the event-target-shim node library published under the MIT license:
  * https://github.com/mysticatea/event-target-shim/blob/master/LICENSE
  * 
- * Bundle generated from https://github.com/mozilla/fxa-pairing-channel.git. Hash:3f2cbe918402baef9611, Chunkhash:4befe20cda6e4faa0272.
+ * Bundle generated from https://github.com/mozilla/fxa-pairing-channel.git. Hash:d6cd81de19f68c6e469c, Chunkhash:3cf39a098c4805094778.
  * 
  */
 (function webpackUniversalModuleDefinition(root, factory) {
@@ -8259,10 +8259,12 @@ function (_EventTarget) {
         }();
 
         stopListening = function stopListening() {
+          socket.removeEventListener('close', onConnectionError);
           socket.removeEventListener('error', onConnectionError);
           socket.removeEventListener('message', onFirstMessage);
         };
 
+        socket.addEventListener('close', onConnectionError);
         socket.addEventListener('error', onConnectionError);
         socket.addEventListener('message', onFirstMessage);
       });

--- a/dist/FxAccountsPairingChannel.js
+++ b/dist/FxAccountsPairingChannel.js
@@ -14,7 +14,7 @@
  * This uses the event-target-shim node library published under the MIT license:
  * https://github.com/mysticatea/event-target-shim/blob/master/LICENSE
  * 
- * Bundle generated from https://github.com/mozilla/fxa-pairing-channel.git. Hash:348f3cf3e80cf7f54f9e, Chunkhash:d34c4d4ec81a46304a5d.
+ * Bundle generated from https://github.com/mozilla/fxa-pairing-channel.git. Hash:b723ebbf7c71d866d60b, Chunkhash:5bb015078a7c08e8cdc5.
  * 
  */
 
@@ -3416,6 +3416,7 @@ if (
 
 /* harmony default export */ var event_target_shim = (EventTarget);
 
+//# sourceMappingURL=event-target-shim.mjs.map
 
 // CONCATENATED MODULE: ./src/index.js
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "PairingChannel", function() { return src_PairingChannel; });
@@ -3504,9 +3505,11 @@ class src_PairingChannel extends EventTarget {
         }
       };
       stopListening = () => {
+        socket.removeEventListener('close', onConnectionError);
         socket.removeEventListener('error', onConnectionError);
         socket.removeEventListener('message', onFirstMessage);
       };
+      socket.addEventListener('close', onConnectionError);
       socket.addEventListener('error', onConnectionError);
       socket.addEventListener('message', onFirstMessage);
     });

--- a/src/index.js
+++ b/src/index.js
@@ -81,9 +81,11 @@ export class PairingChannel extends EventTarget {
         }
       };
       stopListening = () => {
+        socket.removeEventListener('close', onConnectionError);
         socket.removeEventListener('error', onConnectionError);
         socket.removeEventListener('message', onFirstMessage);
       };
+      socket.addEventListener('close', onConnectionError);
       socket.addEventListener('error', onConnectionError);
       socket.addEventListener('message', onFirstMessage);
     });


### PR DESCRIPTION
As described in [bug 1641188](https://bugzilla.mozilla.org/show_bug.cgi?id=1641188), China FxA was misconfigured and pointed to dev instance of channelserver in GCP. We're refreshing the cached pref in desktop Fx with an extension update, but would also like to update fxa-content so that the resulting error message could be localized with an advice to use email+password instead.

When testing our hackish localization fix, we're seeing the WebSocket established and then immediately closed, after a server side "Attempt to connect to unknown channel" message, which leaves the fxa-content with an indefinite spinner.

This patch fixes it in our local testing. I'm not sure if you're interested in taking it, or whether additional test should be created.

Thanks!