### PR TITLE
Prepare v1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,14 +127,15 @@ For ease of consumption, we check the resulting built artifacts in to the Git re
 
 ### Release Process
 
-Use `npm publish` to cut a new release, after ensuring that the tests pass and the
-correct artifacts have been built:
+Use `npm version` and `npm publish` to cut a new release, after ensuring that the tests pass
+and the correct artifacts have been built:
 
 ```
 npm run build
 npm test
+npm version [major | minor | patch] -m "Prepare version %s"
 npm publish
-git tag vX.Y.Z & git push origin vX.Y.Z
+git push origin vX.Y.Z
 ```
 
 Then, open a [Bugzilla Bug](https://bugzilla.mozilla.org/enter_bug.cgi?product=Firefox&component=Firefox%20Accounts) to update the vendored copy of the library in mozilla-central.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-pairing-channel",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-pairing-channel",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "TLS for FxA Pairing",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I knew there'd be something missing in the "cut a release" docs when I actually tried it out 😆 

This adds instructions on how to bump the version number, and then actually does so using that process in order to prepare a fresh release. @vbudhram r?